### PR TITLE
Handle multibyte labels in progress bar

### DIFF
--- a/main.go
+++ b/main.go
@@ -458,8 +458,8 @@ func drawProgressBar(width int, ratio float64, label string) string {
 	}
 	bar := b.String()
 
-	if len(label) > 0 && len(label) < width {
-		start := (width - len(label)) / 2
+	if labelLen := utf8.RuneCountInString(label); labelLen > 0 && labelLen < width {
+		start := (width - labelLen) / 2
 		runes := []rune(bar)
 		labelRunes := []rune(label)
 		for i := 0; i < len(labelRunes) && start+i < len(runes); i++ {


### PR DESCRIPTION
## Summary
- compute label length with `utf8.RuneCountInString` to center multi-rune labels

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68968d8a0fc0832dbbb4b3fdc9b16811